### PR TITLE
fix: export prop types from layout components

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -180,9 +180,13 @@ export { default as ProgressRing } from './viz/ProgressRing.svelte';
 
 // Layout components
 export { default as Header } from './layout/Header.svelte';
+export type { HeaderProps } from './layout/Header.svelte';
 export { default as Sidebar } from './layout/Sidebar.svelte';
+export type { SidebarProps } from './layout/Sidebar.svelte';
 export { default as Panel } from './layout/Panel.svelte';
+export type { PanelProps } from './layout/Panel.svelte';
 export { default as StatusBar } from './layout/StatusBar.svelte';
+export type { StatusBarProps } from './layout/StatusBar.svelte';
 
 // Effects
 export { default as DelaunayBackground } from './effects/DelaunayBackground.svelte';

--- a/src/lib/layout/Header.svelte
+++ b/src/lib/layout/Header.svelte
@@ -1,19 +1,21 @@
-<script lang="ts">
+<script lang="ts" module>
 	import type { Snippet } from 'svelte';
 
-	interface Props {
+	export interface HeaderProps {
 		title: string;
 		subtitle?: string;
 		children?: Snippet;
 		class?: string;
 	}
+</script>
 
+<script lang="ts">
 	let {
 		title,
 		subtitle,
 		children,
 		class: className = ''
-	}: Props = $props();
+	}: HeaderProps = $props();
 </script>
 
 <header class="header {className}">

--- a/src/lib/layout/Panel.svelte
+++ b/src/lib/layout/Panel.svelte
@@ -1,8 +1,7 @@
-<script lang="ts">
+<script lang="ts" module>
 	import type { Snippet } from 'svelte';
-	import { ChevronUp, ChevronDown } from '@lucide/svelte';
 
-	interface Props {
+	export interface PanelProps {
 		title: string;
 		collapsible?: boolean;
 		defaultCollapsed?: boolean;
@@ -10,6 +9,10 @@
 		children: Snippet;
 		class?: string;
 	}
+</script>
+
+<script lang="ts">
+	import { ChevronUp, ChevronDown } from '@lucide/svelte';
 
 	let {
 		title,
@@ -18,7 +21,7 @@
 		headerActions,
 		children,
 		class: className = ''
-	}: Props = $props();
+	}: PanelProps = $props();
 
 	let collapsed = $state(false);
 

--- a/src/lib/layout/Sidebar.svelte
+++ b/src/lib/layout/Sidebar.svelte
@@ -1,14 +1,17 @@
-<script lang="ts">
+<script lang="ts" module>
 	import type { Snippet } from 'svelte';
-	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
 
-	interface Props {
+	export interface SidebarProps {
 		width?: number;
 		collapsed?: boolean;
 		onToggle?: () => void;
 		children: Snippet;
 		class?: string;
 	}
+</script>
+
+<script lang="ts">
+	import { ChevronLeft, ChevronRight } from '@lucide/svelte';
 
 	let {
 		width = 256,
@@ -16,7 +19,7 @@
 		onToggle,
 		children,
 		class: className = ''
-	}: Props = $props();
+	}: SidebarProps = $props();
 
 	const currentWidth = $derived(collapsed ? 48 : width);
 

--- a/src/lib/layout/StatusBar.svelte
+++ b/src/lib/layout/StatusBar.svelte
@@ -1,19 +1,21 @@
-<script lang="ts">
+<script lang="ts" module>
 	import type { Snippet } from 'svelte';
 
-	interface Props {
+	export interface StatusBarProps {
 		children?: Snippet;
 		rightContent?: Snippet;
 		connected?: boolean;
 		class?: string;
 	}
+</script>
 
+<script lang="ts">
 	let {
 		children,
 		rightContent,
 		connected = true,
 		class: className = ''
-	}: Props = $props();
+	}: StatusBarProps = $props();
 </script>
 
 <footer class="status-bar fixed bottom-0 left-0 right-0 h-5 flex items-center justify-between px-3 font-mono text-[9px] z-50 {className}">


### PR DESCRIPTION
## Summary
- Export prop types from layout components (Header, Panel, Sidebar, StatusBar)
- Add type exports to index.ts

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)