### PR TITLE
fix: add content paths to tailwind preset

### DIFF
--- a/tailwind.preset.ts
+++ b/tailwind.preset.ts
@@ -7,7 +7,7 @@ import type { Config } from 'tailwindcss';
  * This preset only provides content paths for library components
  */
 const preset = {
-	content: []
+	content: ['./src/lib/**/*.{svelte,ts}']
 } satisfies Config;
 
 export default preset;


### PR DESCRIPTION
## Summary
- Add content paths to tailwind.preset.ts so Tailwind scans library component files

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)