### PR TITLE
fix: add ARIA attributes to interactive components

### DIFF
--- a/src/lib/core/ActionMenu.svelte
+++ b/src/lib/core/ActionMenu.svelte
@@ -22,7 +22,7 @@
 <svelte:window onclick={handleClickOutside} />
 
 <div class="action-menu">
-	<Button size="sm" onclick={() => (open = !open)}>
+	<Button size="sm" onclick={() => (open = !open)} aria-expanded={open} aria-haspopup="menu">
 		{#if icon}{@render icon()}{/if}
 		{label}
 		<ChevronDown size={12} />

--- a/src/lib/core/MenuItem.svelte
+++ b/src/lib/core/MenuItem.svelte
@@ -27,6 +27,7 @@
 	class:danger={variant === 'danger'}
 	class:admin={variant === 'admin'}
 	{disabled}
+	aria-disabled={disabled}
 	{onclick}
 	role="menuitem"
 >

--- a/src/lib/layout/Panel.svelte
+++ b/src/lib/layout/Panel.svelte
@@ -45,6 +45,8 @@
 		onclick={toggleCollapse}
 		role={collapsible ? 'button' : undefined}
 		tabindex={collapsible ? 0 : -1}
+		aria-expanded={collapsible ? !collapsed : undefined}
+		aria-controls={collapsible ? 'panel-body' : undefined}
 		onkeydown={(e) => {
 			if (collapsible && (e.key === 'Enter' || e.key === ' ')) {
 				e.preventDefault();
@@ -71,7 +73,7 @@
 		{/if}
 	</div>
 	{#if !collapsed}
-		<div class="panel-body">
+		<div class="panel-body" id="panel-body">
 			{@render children()}
 		</div>
 	{/if}

--- a/src/lib/layout/Sidebar.svelte
+++ b/src/lib/layout/Sidebar.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <aside class="sidebar {className}" style="width: {currentWidth}px;">
-	<div class="sidebar-content">
+	<div class="sidebar-content" aria-hidden={collapsed}>
 		{@render children()}
 	</div>
 	<div class="sidebar-footer">
@@ -38,6 +38,7 @@
 			onclick={handleToggle}
 			class="sidebar-toggle"
 			aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+			aria-expanded={!collapsed}
 		>
 			{#if collapsed}
 				<ChevronRight size={14} />


### PR DESCRIPTION
## Summary
- Add aria-expanded and aria-haspopup to ActionMenu trigger button
- Add aria-expanded and aria-controls to Panel collapsible header
- Add aria-disabled to MenuItem when disabled
- Add aria-hidden to Sidebar content when collapsed
- Add aria-expanded to Sidebar toggle button

Closes #6