### PR TITLE
fix: align color token naming convention in theme.ts

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -36,7 +36,10 @@ export const darkTheme = {
 			negativeMuted: '#cc3333',
 			warning: '#ffaa00',
 			warningHover: '#ffbb33',
-			info: '#00aaff'
+			warningMuted: 'rgba(255, 170, 0, 0.15)',
+			info: '#00aaff',
+			infoMuted: 'rgba(0, 170, 255, 0.15)',
+			neutral: '#888888'
 		},
 		chart: {
 			line1: '#00ff88',
@@ -107,15 +110,18 @@ export function themeToCSS(t: Theme = darkTheme): string {
 		--accent-brand: ${t.colors.accent.brand};
 		--accent-brand-hover: ${t.colors.accent.brandHover};
 		--accent-brand-muted: ${t.colors.accent.brandMuted};
-		--color-positive: ${t.colors.semantic.positive};
-		--color-positive-hover: ${t.colors.semantic.positiveHover};
-		--color-positive-muted: ${t.colors.semantic.positiveMuted};
-		--color-negative: ${t.colors.semantic.negative};
-		--color-negative-hover: ${t.colors.semantic.negativeHover};
-		--color-negative-muted: ${t.colors.semantic.negativeMuted};
-		--color-warning: ${t.colors.semantic.warning};
-		--color-warning-hover: ${t.colors.semantic.warningHover};
-		--color-info: ${t.colors.semantic.info};
+		--positive: ${t.colors.semantic.positive};
+		--positive-hover: ${t.colors.semantic.positiveHover};
+		--positive-muted: ${t.colors.semantic.positiveMuted};
+		--negative: ${t.colors.semantic.negative};
+		--negative-hover: ${t.colors.semantic.negativeHover};
+		--negative-muted: ${t.colors.semantic.negativeMuted};
+		--warning: ${t.colors.semantic.warning};
+		--warning-hover: ${t.colors.semantic.warningHover};
+		--warning-muted: ${t.colors.semantic.warningMuted};
+		--info: ${t.colors.semantic.info};
+		--info-muted: ${t.colors.semantic.infoMuted};
+		--neutral: ${t.colors.semantic.neutral};
 		--chart-line1: ${t.colors.chart.line1};
 		--chart-line2: ${t.colors.chart.line2};
 		--chart-line3: ${t.colors.chart.line3};


### PR DESCRIPTION
## Summary
- Fix color token inconsistencies between `theme.ts` and `theme.svelte.ts` by renaming CSS variable outputs from `--color-*` prefix to unprefixed names (e.g., `--positive` instead of `--color-positive`)
- Add missing semantic color tokens: `warningMuted`, `infoMuted`, `neutral` to match the complete set used in `styles.css` and `theme.svelte.ts`
- Ensure consistency across the theming system where the `@theme` block in `styles.css` maps unprefixed base variables to `--color-*` prefixed Tailwind tokens

## Test plan
- [ ] Verify components using Tailwind classes like `bg-color-positive`, `text-color-warning` render correctly
- [ ] Verify components using CSS variables like `var(--color-positive)` in inline styles work properly
- [ ] Check that Alert, ProgressBar, Toast, and other semantic-color-using components display correct colors
- [ ] Test both dark and light theme modes

Closes #11

---
Generated with [Claude Code](https://claude.com/claude-code)