### PR TITLE
feat: add loading state support to form components

### DIFF
--- a/src/lib/core/Checkbox.svelte
+++ b/src/lib/core/Checkbox.svelte
@@ -6,6 +6,8 @@
 		checked?: boolean;
 		/** Disable interactions */
 		disabled?: boolean;
+		/** Show loading spinner and disable interactions */
+		loading?: boolean;
 		/** Size preset */
 		size?: CheckboxSize;
 		/** HTML id attribute for label association */
@@ -27,11 +29,12 @@
 
 <script lang="ts">
 	import { Checkbox } from 'bits-ui';
-	import { Check } from '@lucide/svelte';
+	import { Check, Loader2 } from '@lucide/svelte';
 
 	let {
 		checked = $bindable(false),
 		disabled = false,
+		loading = false,
 		size = 'md',
 		id,
 		name,
@@ -41,6 +44,8 @@
 		class: className = '',
 		onchange
 	}: CheckboxProps = $props();
+
+	const isDisabled = $derived(disabled || loading);
 
 	const sizeClasses: Record<CheckboxSize, string> = {
 		sm: 'h-4 w-4',
@@ -66,16 +71,19 @@
 	{id}
 	{name}
 	{checked}
-	{disabled}
+	disabled={isDisabled}
 	onCheckedChange={handleChange}
 	aria-label={ariaLabel}
 	aria-describedby={ariaDescribedby}
 	aria-invalid={ariaInvalid}
+	aria-busy={loading}
 	class="inline-flex items-center justify-center rounded border border-border-default bg-bg-secondary transition-colors hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/20 focus-visible:border-accent-brand disabled:opacity-50 disabled:cursor-not-allowed data-[state=checked]:bg-accent-brand data-[state=checked]:border-accent-brand cursor-pointer {sizeClasses[size]} {className}"
 >
 	{#snippet children({ checked: isChecked })}
 		<span class="text-white flex items-center justify-center">
-			{#if isChecked}
+			{#if loading}
+				<Loader2 size={iconSizes[size]} class="animate-spin text-text-muted" />
+			{:else if isChecked}
 				<Check size={iconSizes[size]} />
 			{/if}
 		</span>

--- a/src/lib/core/Input.svelte
+++ b/src/lib/core/Input.svelte
@@ -10,6 +10,8 @@
 		size?: InputSize;
 		align?: InputAlign;
 		disabled?: boolean;
+		/** Show loading spinner and disable interactions */
+		loading?: boolean;
 		readonly?: boolean;
 		required?: boolean;
 		error?: boolean;
@@ -28,6 +30,8 @@
 </script>
 
 <script lang="ts">
+	import { Loader2 } from '@lucide/svelte';
+
 	let {
 		type = 'text',
 		value = $bindable(''),
@@ -35,6 +39,7 @@
 		size = 'md',
 		align = 'left',
 		disabled = false,
+		loading = false,
 		readonly = false,
 		required = false,
 		error = false,
@@ -50,6 +55,14 @@
 		onfocus,
 		onblur
 	}: InputProps = $props();
+
+	const iconSizes: Record<InputSize, number> = {
+		sm: 14,
+		md: 16,
+		lg: 18
+	};
+
+	const isDisabled = $derived(disabled || loading);
 
 	const sizeClasses: Record<InputSize, string> = {
 		sm: 'px-2 py-1.5 text-sm',
@@ -71,14 +84,15 @@
 		{type}
 		bind:value
 		{placeholder}
-		{disabled}
+		disabled={isDisabled}
 		{required}
 		readonly={readonly}
 		aria-label={ariaLabel}
 		aria-describedby={ariaDescribedby}
 		aria-invalid={error}
 		aria-required={required}
-		class="w-full bg-bg-secondary border rounded-md font-mono text-text-primary placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:cursor-not-allowed read-only:bg-bg-tertiary read-only:cursor-default {error ? 'border-negative focus-visible:border-negative focus-visible:ring-negative/20' : 'border-border-default focus-visible:border-accent-brand focus-visible:ring-accent-brand/20'} {sizeClasses[size]} {alignClasses[align]} {prefix ? 'pl-12' : ''} {suffix ? 'pr-12' : ''}"
+		aria-busy={loading}
+		class="w-full bg-bg-secondary border rounded-md font-mono text-text-primary placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:cursor-not-allowed read-only:bg-bg-tertiary read-only:cursor-default {error ? 'border-negative focus-visible:border-negative focus-visible:ring-negative/20' : 'border-border-default focus-visible:border-accent-brand focus-visible:ring-accent-brand/20'} {sizeClasses[size]} {alignClasses[align]} {prefix ? 'pl-12' : ''} {suffix || loading ? 'pr-12' : ''}"
 		{oninput}
 		{onchange}
 		{onfocus}
@@ -87,7 +101,11 @@
 	{#if prefix}
 		<span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted text-sm pointer-events-none">{prefix}</span>
 	{/if}
-	{#if suffix}
+	{#if loading}
+		<span class="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none">
+			<Loader2 size={iconSizes[size]} class="animate-spin" />
+		</span>
+	{:else if suffix}
 		<span class="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted text-sm pointer-events-none">{suffix}</span>
 	{/if}
 </div>

--- a/src/lib/core/RadioGroup.svelte
+++ b/src/lib/core/RadioGroup.svelte
@@ -16,6 +16,8 @@
 		size?: RadioGroupSize;
 		/** Disable interactions */
 		disabled?: boolean;
+		/** Show loading spinner and disable interactions */
+		loading?: boolean;
 		/** Layout orientation */
 		orientation?: 'horizontal' | 'vertical';
 		/** HTML name attribute for form submission */
@@ -37,12 +39,14 @@
 
 <script lang="ts">
 	import { RadioGroup } from 'bits-ui';
+	import { Loader2 } from '@lucide/svelte';
 
 	let {
 		value = $bindable(''),
 		options,
 		size = 'md',
 		disabled = false,
+		loading = false,
 		orientation = 'vertical',
 		name,
 		required = false,
@@ -52,6 +56,8 @@
 		class: className = '',
 		onchange
 	}: RadioGroupProps = $props();
+
+	const isDisabled = $derived(disabled || loading);
 
 	const items = $derived(
 		options.map((opt) => (typeof opt === 'string' ? { value: opt, label: opt } : opt))
@@ -75,39 +81,53 @@
 		lg: 'text-base'
 	};
 
+	const iconSizes: Record<RadioGroupSize, number> = {
+		sm: 14,
+		md: 16,
+		lg: 18
+	};
+
 	function handleChange(newValue: string) {
 		value = newValue;
 		onchange?.(newValue);
 	}
 </script>
 
-<RadioGroup.Root
-	{name}
-	{value}
-	{disabled}
-	{required}
-	onValueChange={handleChange}
-	aria-label={ariaLabel}
-	aria-describedby={ariaDescribedby}
-	aria-invalid={ariaInvalid}
-	class="flex {orientation === 'vertical' ? 'flex-col gap-2' : 'flex-row gap-4'} {className}"
->
-	{#each items as item}
-		<div class="flex items-center gap-2">
-			<RadioGroup.Item
-				value={item.value}
-				disabled={item.disabled}
-				class="inline-flex items-center justify-center rounded-full border border-border-default bg-bg-secondary transition-colors hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/20 focus-visible:border-accent-brand disabled:opacity-50 disabled:cursor-not-allowed data-[state=checked]:border-accent-brand {radioSizes[size]}"
-			>
-				{#snippet children({ checked })}
-					{#if checked}
-						<span class="rounded-full bg-accent-brand {indicatorSizes[size]}"></span>
-					{/if}
-				{/snippet}
-			</RadioGroup.Item>
-			<span class="text-text-primary {textSizes[size]} cursor-pointer">
-				{item.label}
-			</span>
-		</div>
-	{/each}
-</RadioGroup.Root>
+<div class="relative inline-block {className}">
+	<RadioGroup.Root
+		{name}
+		{value}
+		disabled={isDisabled}
+		{required}
+		onValueChange={handleChange}
+		aria-label={ariaLabel}
+		aria-describedby={ariaDescribedby}
+		aria-invalid={ariaInvalid}
+		aria-busy={loading}
+		class="flex {orientation === 'vertical' ? 'flex-col gap-2' : 'flex-row gap-4'}"
+	>
+		{#each items as item}
+			<div class="flex items-center gap-2">
+				<RadioGroup.Item
+					value={item.value}
+					disabled={item.disabled}
+					class="inline-flex items-center justify-center rounded-full border border-border-default bg-bg-secondary transition-colors hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/20 focus-visible:border-accent-brand disabled:opacity-50 disabled:cursor-not-allowed data-[state=checked]:border-accent-brand {radioSizes[size]}"
+				>
+					{#snippet children({ checked })}
+						{#if checked}
+							<span class="rounded-full bg-accent-brand {indicatorSizes[size]}"></span>
+						{/if}
+					{/snippet}
+				</RadioGroup.Item>
+				<span class="text-text-primary {textSizes[size]} cursor-pointer {isDisabled ? 'opacity-50' : ''}">
+					{item.label}
+				</span>
+			</div>
+		{/each}
+	</RadioGroup.Root>
+	{#if loading}
+		<span class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-full pl-2 text-text-muted">
+			<Loader2 size={iconSizes[size]} class="animate-spin" />
+		</span>
+	{/if}
+</div>

--- a/src/lib/core/Select.svelte
+++ b/src/lib/core/Select.svelte
@@ -16,6 +16,8 @@
 		size?: SelectSize;
 		/** Disable interactions */
 		disabled?: boolean;
+		/** Show loading spinner and disable interactions */
+		loading?: boolean;
 		/** Required field */
 		required?: boolean;
 		/** Placeholder text when no value selected */
@@ -41,13 +43,14 @@
 
 <script lang="ts">
 	import { Select } from 'bits-ui';
-	import { ChevronDown, Check, X } from '@lucide/svelte';
+	import { ChevronDown, Check, X, Loader2 } from '@lucide/svelte';
 
 	let {
 		value = $bindable(''),
 		options,
 		size = 'md',
 		disabled = false,
+		loading = false,
 		required = false,
 		placeholder = 'Select...',
 		id,
@@ -59,6 +62,8 @@
 		class: className = '',
 		onchange
 	}: SelectProps = $props();
+
+	const isDisabled = $derived(disabled || loading);
 
 	function handleClear(e: MouseEvent) {
 		e.stopPropagation();
@@ -95,7 +100,7 @@
 <div class="w-full {className}">
 	<Select.Root
 		type="single"
-		{disabled}
+		disabled={isDisabled}
 		{required}
 		{value}
 		onValueChange={handleValueChange}
@@ -107,23 +112,30 @@
 			aria-label={ariaLabel}
 			aria-describedby={ariaDescribedby}
 			aria-invalid={ariaInvalid}
+			aria-busy={loading}
 			class="relative w-full appearance-none bg-bg-secondary border border-border-default rounded-md font-mono text-text-primary cursor-pointer transition-colors hover:border-border-strong focus-visible:outline-none focus-visible:border-accent-brand focus-visible:ring-2 focus-visible:ring-accent-brand/20 disabled:opacity-50 disabled:cursor-not-allowed text-left {sizeClasses[size]} {rightPadding}"
 		>
 		<span class={value ? '' : 'text-text-muted'}>{selectedLabel}</span>
 		<span class="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1">
-			{#if clearable && value && !disabled}
-				<button
-					type="button"
-					onclick={handleClear}
-					class="p-0.5 rounded-sm text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors"
-					aria-label="Clear selection"
-				>
-					<X size={iconSizes[size] - 2} />
-				</button>
+			{#if loading}
+				<span class="pointer-events-none text-text-muted">
+					<Loader2 size={iconSizes[size]} class="animate-spin" />
+				</span>
+			{:else}
+				{#if clearable && value && !disabled}
+					<button
+						type="button"
+						onclick={handleClear}
+						class="p-0.5 rounded-sm text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors"
+						aria-label="Clear selection"
+					>
+						<X size={iconSizes[size] - 2} />
+					</button>
+				{/if}
+				<span class="pointer-events-none text-text-muted">
+					<ChevronDown size={iconSizes[size]} />
+				</span>
 			{/if}
-			<span class="pointer-events-none text-text-muted">
-				<ChevronDown size={iconSizes[size]} />
-			</span>
 		</span>
 	</Select.Trigger>
 

--- a/src/lib/core/Textarea.svelte
+++ b/src/lib/core/Textarea.svelte
@@ -7,6 +7,8 @@
 		size?: TextareaSize;
 		rows?: number;
 		disabled?: boolean;
+		/** Show loading spinner and disable interactions */
+		loading?: boolean;
 		readonly?: boolean;
 		required?: boolean;
 		error?: boolean;
@@ -23,12 +25,15 @@
 </script>
 
 <script lang="ts">
+	import { Loader2 } from '@lucide/svelte';
+
 	let {
 		value = $bindable(''),
 		placeholder = '',
 		size = 'md',
 		rows = 3,
 		disabled = false,
+		loading = false,
 		readonly = false,
 		required = false,
 		error = false,
@@ -43,31 +48,45 @@
 		onblur
 	}: TextareaProps = $props();
 
+	const isDisabled = $derived(disabled || loading);
+
 	const sizeClasses: Record<TextareaSize, string> = {
 		sm: 'px-2 py-1.5 text-sm',
 		md: 'px-3 py-2 text-sm',
 		lg: 'px-4 py-3 text-base'
 	};
+
+	const iconSizes: Record<TextareaSize, number> = {
+		sm: 14,
+		md: 16,
+		lg: 18
+	};
 </script>
 
-<div class="w-full {className}">
+<div class="relative w-full {className}">
 	<textarea
 		{id}
 		{name}
 		bind:value
 		{placeholder}
 		{rows}
-		{disabled}
+		disabled={isDisabled}
 		{required}
 		readonly={readonly}
 		aria-label={ariaLabel}
 		aria-describedby={ariaDescribedby}
 		aria-invalid={error}
 		aria-required={required}
+		aria-busy={loading}
 		class="w-full resize-y bg-bg-secondary border rounded-md font-mono text-text-primary placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:cursor-not-allowed read-only:bg-bg-tertiary read-only:cursor-default {error ? 'border-negative focus-visible:border-negative focus-visible:ring-negative/20' : 'border-border-default focus-visible:border-accent-brand focus-visible:ring-accent-brand/20'} {sizeClasses[size]}"
 		{oninput}
 		{onchange}
 		{onfocus}
 		{onblur}
 	></textarea>
+	{#if loading}
+		<span class="absolute right-3 top-3 text-text-muted pointer-events-none">
+			<Loader2 size={iconSizes[size]} class="animate-spin" />
+		</span>
+	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Add optional `loading?: boolean` prop to Input, Select, Textarea, RadioGroup, and Checkbox components
- Display visual spinner indicator (Loader2 icon) when loading
- Set `aria-busy="true"` for accessibility during loading state
- Auto-disable components during loading (combined with existing disabled prop)

## Test plan
- [ ] Verify each form component renders spinner when `loading={true}`
- [ ] Verify components are disabled during loading state
- [ ] Verify `aria-busy` attribute is set correctly for screen readers
- [ ] Verify loading spinner styling matches component size variant

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)