### PR TITLE
fix: standardize size scale across components

### DIFF
--- a/src/lib/core/AssetIcon.svelte
+++ b/src/lib/core/AssetIcon.svelte
@@ -6,7 +6,7 @@
 	 * - If unicode provided: shows unicode symbol
 	 * - Otherwise: shows first 2 chars of symbol
 	 */
-	export type AssetIconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+	export type AssetIconSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface AssetIconProps {
 		/** Asset symbol (e.g., "BTC", "USD"). */
@@ -25,8 +25,7 @@
 		xs: 12,
 		sm: 16,
 		md: 20,
-		lg: 24,
-		xl: 32
+		lg: 24
 	};
 </script>
 
@@ -48,8 +47,7 @@
 		xs: 'w-3 h-3 text-[10px]',
 		sm: 'w-4 h-4 text-xs',
 		md: 'w-5 h-5 text-sm',
-		lg: 'w-6 h-6 text-base',
-		xl: 'w-8 h-8 text-xl'
+		lg: 'w-6 h-6 text-base'
 	};
 </script>
 

--- a/src/lib/core/Checkbox.svelte
+++ b/src/lib/core/Checkbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type CheckboxSize = 'sm' | 'md' | 'lg';
+	export type CheckboxSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface CheckboxProps {
 		/** Checked state (bindable) */
@@ -43,12 +43,14 @@
 	}: CheckboxProps = $props();
 
 	const sizeClasses: Record<CheckboxSize, string> = {
+		xs: 'h-3.5 w-3.5',
 		sm: 'h-4 w-4',
 		md: 'h-5 w-5',
 		lg: 'h-6 w-6'
 	};
 
 	const iconSizes: Record<CheckboxSize, number> = {
+		xs: 10,
 		sm: 12,
 		md: 14,
 		lg: 16

--- a/src/lib/core/DateRangePicker.svelte
+++ b/src/lib/core/DateRangePicker.svelte
@@ -2,7 +2,7 @@
 	import type { DateValue } from '@internationalized/date';
 	import type { DateRange } from 'bits-ui';
 
-	export type DateRangePickerSize = 'sm' | 'md' | 'lg';
+	export type DateRangePickerSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface DateModifier {
 		/** Match function - return true if date should be modified */
@@ -74,12 +74,14 @@
 	const df = new DateFormatter('en-US', { dateStyle: 'medium' });
 
 	const sizeClasses: Record<DateRangePickerSize, string> = {
+		xs: 'py-1 px-1.5 text-xs',
 		sm: 'py-1.5 px-2 text-sm',
 		md: 'py-2 px-3 text-sm',
 		lg: 'py-3 px-4 text-base'
 	};
 
 	const iconSizes: Record<DateRangePickerSize, number> = {
+		xs: 12,
 		sm: 14,
 		md: 16,
 		lg: 18

--- a/src/lib/core/EmptyState.svelte
+++ b/src/lib/core/EmptyState.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type EmptyStateSize = 'sm' | 'md' | 'lg';
+	export type EmptyStateSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface EmptyStateProps {
 		icon?: import('svelte').Component;
@@ -30,24 +30,28 @@
 	const effectiveSize = $derived(compact ? 'sm' : size);
 
 	const iconSizes: Record<EmptyStateSize, number> = {
+		xs: 16,
 		sm: 24,
 		md: 48,
 		lg: 64
 	};
 
 	const contentClasses: Record<EmptyStateSize, string> = {
+		xs: 'gap-2 p-3',
 		sm: 'gap-3 p-4',
 		md: 'gap-4 p-8',
 		lg: 'gap-6 p-12'
 	};
 
 	const titleClasses: Record<EmptyStateSize, string> = {
+		xs: 'text-xs',
 		sm: 'text-sm',
 		md: 'text-base',
 		lg: 'text-lg'
 	};
 
 	const descClasses: Record<EmptyStateSize, string> = {
+		xs: 'text-[10px]',
 		sm: 'text-xs',
 		md: 'text-sm',
 		lg: 'text-[15px]'

--- a/src/lib/core/Input.svelte
+++ b/src/lib/core/Input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type InputSize = 'sm' | 'md' | 'lg';
+	export type InputSize = 'xs' | 'sm' | 'md' | 'lg';
 	export type InputAlign = 'left' | 'center' | 'right';
 	export type InputType = 'text' | 'number' | 'email' | 'password' | 'search' | 'tel' | 'url';
 
@@ -52,6 +52,7 @@
 	}: InputProps = $props();
 
 	const sizeClasses: Record<InputSize, string> = {
+		xs: 'px-1.5 py-1 text-xs',
 		sm: 'px-2 py-1.5 text-sm',
 		md: 'px-3 py-2 text-sm',
 		lg: 'px-4 py-3 text-base'

--- a/src/lib/core/MetricCard.svelte
+++ b/src/lib/core/MetricCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
 	export type MetricCardVariant = 'default' | 'positive' | 'negative' | 'warning';
-	export type MetricCardSize = 'sm' | 'md' | 'lg';
+	export type MetricCardSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface MetricCardProps {
 		label: string;
@@ -16,6 +16,7 @@
 	let { label, value, icon, variant = 'default', size = 'md', class: className = '' }: MetricCardProps = $props();
 
 	const sizeClasses: Record<MetricCardSize, { card: string; icon: string; value: string }> = {
+		xs: { card: 'gap-1.5 p-2', icon: 'w-6 h-6', value: 'text-base' },
 		sm: { card: 'gap-2 p-3', icon: 'w-8 h-8', value: 'text-lg' },
 		md: { card: 'gap-3 p-4', icon: 'w-10 h-10', value: 'text-xl' },
 		lg: { card: 'gap-4 p-6', icon: 'w-12 h-12', value: 'text-2xl' }
@@ -36,7 +37,7 @@
 	{#if icon}
 		{@const Icon = icon}
 		<div class="flex shrink-0 items-center justify-center rounded-md {sc.icon} {vc.icon}">
-			<Icon size={size === 'lg' ? 20 : 16} />
+			<Icon size={size === 'xs' ? 12 : size === 'lg' ? 20 : 16} />
 		</div>
 	{/if}
 	<div class="flex min-w-0 flex-col gap-1">

--- a/src/lib/core/Numeric.svelte
+++ b/src/lib/core/Numeric.svelte
@@ -42,7 +42,7 @@
 		| 'accent'; // brand color
 
 	// Size presets
-	export type NumericSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+	export type NumericSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface NumericProps {
 		/** The numeric value to display */
@@ -263,8 +263,7 @@
 		xs: 'text-[10px]',
 		sm: 'text-[11px]',
 		md: 'text-[13px]',
-		lg: 'text-base',
-		xl: 'text-xl'
+		lg: 'text-base'
 	};
 
 	// Variant classes

--- a/src/lib/core/PrivacyToggle.svelte
+++ b/src/lib/core/PrivacyToggle.svelte
@@ -11,7 +11,7 @@
 	 * <PrivacyToggle size="sm" />
 	 */
 
-	export type PrivacyToggleSize = 'sm' | 'md' | 'lg';
+	export type PrivacyToggleSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface PrivacyToggleProps {
 		/** Size preset (default: 'md') */
@@ -34,13 +34,14 @@
 	const privacy = getPrivacyContext();
 
 	// Icon size based on button size
-	const iconSize = $derived(size === 'sm' ? 14 : size === 'lg' ? 20 : 16);
+	const iconSize = $derived(size === 'xs' ? 12 : size === 'sm' ? 14 : size === 'lg' ? 20 : 16);
 
 	function handleClick() {
 		privacy.toggle();
 	}
 
 	const sizeClasses: Record<PrivacyToggleSize, string> = {
+		xs: 'py-0.5 px-1 text-[9px]',
 		sm: 'py-1 px-1.5 text-[10px]',
 		md: 'py-1.5 px-2 text-[11px]',
 		lg: 'py-2 px-2.5 text-xs'

--- a/src/lib/core/ProgressBar.svelte
+++ b/src/lib/core/ProgressBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type ProgressBarSize = 'sm' | 'md' | 'lg';
+	export type ProgressBarSize = 'xs' | 'sm' | 'md' | 'lg';
 	export type ProgressBarVariant = 'default' | 'success' | 'warning' | 'danger';
 
 	export interface ProgressBarProps {
@@ -27,6 +27,7 @@
 	const percentage = $derived(Math.min(100, Math.max(0, (value / max) * 100)));
 
 	const sizeClasses: Record<ProgressBarSize, string> = {
+		xs: 'h-0.5',
 		sm: 'h-1',
 		md: 'h-2',
 		lg: 'h-3'

--- a/src/lib/core/RadioGroup.svelte
+++ b/src/lib/core/RadioGroup.svelte
@@ -5,7 +5,7 @@
 		disabled?: boolean;
 	}
 
-	export type RadioGroupSize = 'sm' | 'md' | 'lg';
+	export type RadioGroupSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface RadioGroupProps {
 		/** Selected value (bindable) */
@@ -58,18 +58,21 @@
 	);
 
 	const radioSizes: Record<RadioGroupSize, string> = {
+		xs: 'h-3.5 w-3.5',
 		sm: 'h-4 w-4',
 		md: 'h-5 w-5',
 		lg: 'h-6 w-6'
 	};
 
 	const indicatorSizes: Record<RadioGroupSize, string> = {
+		xs: 'h-1.5 w-1.5',
 		sm: 'h-2 w-2',
 		md: 'h-2.5 w-2.5',
 		lg: 'h-3 w-3'
 	};
 
 	const textSizes: Record<RadioGroupSize, string> = {
+		xs: 'text-xs',
 		sm: 'text-sm',
 		md: 'text-sm',
 		lg: 'text-base'

--- a/src/lib/core/Select.svelte
+++ b/src/lib/core/Select.svelte
@@ -5,7 +5,7 @@
 		disabled?: boolean;
 	}
 
-	export type SelectSize = 'sm' | 'md' | 'lg';
+	export type SelectSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface SelectProps {
 		/** Selected value (bindable) */
@@ -73,14 +73,16 @@
 	const selectedLabel = $derived(items.find((item) => item.value === value)?.label ?? placeholder);
 
 	const sizeClasses: Record<SelectSize, string> = {
+		xs: 'py-1 pl-1.5 text-xs',
 		sm: 'py-1.5 pl-2 text-sm',
 		md: 'py-2 pl-3 text-sm',
 		lg: 'py-3 pl-4 text-base'
 	};
 
-	const rightPadding = $derived(clearable && value ? 'pr-14' : size === 'sm' ? 'pr-8' : size === 'md' ? 'pr-10' : 'pr-12');
+	const rightPadding = $derived(clearable && value ? 'pr-14' : size === 'xs' ? 'pr-6' : size === 'sm' ? 'pr-8' : size === 'md' ? 'pr-10' : 'pr-12');
 
 	const iconSizes: Record<SelectSize, number> = {
+		xs: 12,
 		sm: 14,
 		md: 16,
 		lg: 18

--- a/src/lib/core/Slider.svelte
+++ b/src/lib/core/Slider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type SliderSize = 'sm' | 'md' | 'lg';
+	export type SliderSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface SliderProps {
 		/** Current value(s) (bindable) */
@@ -42,18 +42,21 @@
 	}: SliderProps = $props();
 
 	const rootClasses: Record<SliderSize, string> = {
+		xs: 'h-3.5',
 		sm: 'h-4',
 		md: 'h-5',
 		lg: 'h-6'
 	};
 
 	const trackClasses: Record<SliderSize, string> = {
+		xs: 'h-0.5',
 		sm: 'h-1',
 		md: 'h-1.5',
 		lg: 'h-2'
 	};
 
 	const thumbClasses: Record<SliderSize, string> = {
+		xs: 'size-3',
 		sm: 'size-3.5',
 		md: 'size-4',
 		lg: 'size-5'

--- a/src/lib/core/StatsGrid.svelte
+++ b/src/lib/core/StatsGrid.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
 	export type StatsGridVariant = 'default' | 'positive' | 'negative' | 'warning';
-	export type StatsGridSize = 'sm' | 'md' | 'lg';
+	export type StatsGridSize = 'xs' | 'sm' | 'md' | 'lg';
 	export type StatsGridColumns = 2 | 3 | 4;
 
 	export interface StatItem {
@@ -27,6 +27,7 @@
 	};
 
 	const sizeClasses: Record<StatsGridSize, string> = {
+		xs: 'text-base',
 		sm: 'text-lg',
 		md: 'text-2xl',
 		lg: 'text-3xl'

--- a/src/lib/core/StatusBadge.svelte
+++ b/src/lib/core/StatusBadge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
 	export type StatusBadgeVariant = 'default' | 'info' | 'success' | 'warning' | 'danger';
-	export type StatusBadgeSize = 'sm' | 'md' | 'lg';
+	export type StatusBadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface StatusBadgeProps {
 		label: string;
@@ -24,6 +24,7 @@
 	};
 
 	const sizeClasses: Record<StatusBadgeSize, string> = {
+		xs: 'text-[9px]',
 		sm: 'text-[10px]',
 		md: 'text-[11px]',
 		lg: 'text-xs'
@@ -38,6 +39,7 @@
 	};
 
 	const iconSizes: Record<StatusBadgeSize, number> = {
+		xs: 8,
 		sm: 10,
 		md: 12,
 		lg: 14

--- a/src/lib/core/Switch.svelte
+++ b/src/lib/core/Switch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type SwitchSize = 'sm' | 'md' | 'lg';
+	export type SwitchSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface SwitchProps {
 		/** Checked state (bindable) */
@@ -39,12 +39,14 @@
 	}: SwitchProps = $props();
 
 	const trackSizes: Record<SwitchSize, string> = {
+		xs: 'h-3.5 w-6',
 		sm: 'h-4 w-7',
 		md: 'h-5 w-9',
 		lg: 'h-6 w-11'
 	};
 
 	const thumbSizes: Record<SwitchSize, string> = {
+		xs: 'h-2.5 w-2.5 data-[state=checked]:translate-x-2.5',
 		sm: 'h-3 w-3 data-[state=checked]:translate-x-3',
 		md: 'h-4 w-4 data-[state=checked]:translate-x-4',
 		lg: 'h-5 w-5 data-[state=checked]:translate-x-5'

--- a/src/lib/core/Tabs.svelte
+++ b/src/lib/core/Tabs.svelte
@@ -7,7 +7,7 @@
 		disabled?: boolean;
 	}
 
-	export type TabsSize = 'sm' | 'md' | 'lg';
+	export type TabsSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface TabsProps {
 		value?: string;
@@ -43,6 +43,7 @@
 	});
 
 	const triggerSizes: Record<TabsSize, string> = {
+		xs: 'px-2 py-1 text-[10px]',
 		sm: 'px-3 py-1.5 text-xs',
 		md: 'px-4 py-2 text-sm',
 		lg: 'px-5 py-2.5 text-base'

--- a/src/lib/core/Text.svelte
+++ b/src/lib/core/Text.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type TextSize = 'xs' | 'sm' | 'md' | 'lg';
+	export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 	export type TextVariant = 'primary' | 'secondary' | 'muted' | 'positive' | 'negative' | 'warning';
 	export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
 	export type TextElement = 'p' | 'span' | 'div' | 'label';
@@ -32,7 +32,8 @@
 		xs: 'text-xs',
 		sm: 'text-sm',
 		md: 'text-md',
-		lg: 'text-lg'
+		lg: 'text-lg',
+		xl: 'text-xl'
 	};
 
 	const variantClasses: Record<TextVariant, string> = {

--- a/src/lib/core/Textarea.svelte
+++ b/src/lib/core/Textarea.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type TextareaSize = 'sm' | 'md' | 'lg';
+	export type TextareaSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface TextareaProps {
 		value?: string;
@@ -44,6 +44,7 @@
 	}: TextareaProps = $props();
 
 	const sizeClasses: Record<TextareaSize, string> = {
+		xs: 'px-1.5 py-1 text-xs',
 		sm: 'px-2 py-1.5 text-sm',
 		md: 'px-3 py-2 text-sm',
 		lg: 'px-4 py-3 text-base'

--- a/src/lib/core/ThemeToggle.svelte
+++ b/src/lib/core/ThemeToggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	export type ThemeToggleSize = 'sm' | 'md' | 'lg';
+	export type ThemeToggleSize = 'xs' | 'sm' | 'md' | 'lg';
 
 	export interface ThemeToggleProps {
 		size?: ThemeToggleSize;
@@ -14,9 +14,10 @@
 
 	let { size = 'md', class: className = '', showLabel = false }: ThemeToggleProps = $props();
 
-	const iconSize = $derived(size === 'sm' ? 14 : size === 'lg' ? 20 : 16);
+	const iconSize = $derived(size === 'xs' ? 12 : size === 'sm' ? 14 : size === 'lg' ? 20 : 16);
 
 	const sizeClasses: Record<ThemeToggleSize, string> = {
+		xs: 'py-0.5 px-1 text-[9px]',
 		sm: 'py-1 px-1.5 text-[10px]',
 		md: 'py-1.5 px-2 text-[11px]',
 		lg: 'py-2 px-2.5 text-xs'


### PR DESCRIPTION
## Summary

- Standardize the size prop API to use `xs | sm | md | lg` consistently across all components
- Add xs size to 16 components that were previously missing it
- Add xl size to Text component for typography consistency with Heading
- Remove xl size from Numeric and AssetIcon to align with the standard scale

## Changes

| Component Type | Size Scale |
|---------------|------------|
| Standard components | `xs \| sm \| md \| lg` |
| Typography (Heading, Text) | `xs \| sm \| md \| lg \| xl` (+ 2xl for Heading) |

### Components Updated

**Added xs size:**
- Input, Checkbox, Select, Switch, Textarea
- RadioGroup, Tabs, ProgressBar, Slider
- EmptyState, MetricCard, StatsGrid
- ThemeToggle, PrivacyToggle, StatusBadge, DateRangePicker

**Added xl size:**
- Text (for typography consistency with Heading)

**Removed xl size:**
- Numeric, AssetIcon (to align with standard scale)

## Test plan

- [ ] Verify xs size renders correctly for all updated form components
- [ ] Verify Text component supports xl size
- [ ] Verify Numeric and AssetIcon work without xl size
- [ ] Check no TypeScript errors related to size prop types

Closes #8

---
Generated with [Claude Code](https://claude.com/claude-code)